### PR TITLE
Show 'weighted win percent' for stats

### DIFF
--- a/lib/listeners/stats.js
+++ b/lib/listeners/stats.js
@@ -13,7 +13,7 @@ exports.callback = function (route, message, response) {
     }
 
     const userMap =_.chain(result).map(data => [data.user.id, data.user.real_name || data.user.name]).object().value()
-    response(rankings.map((user, index) => `${index + 1}) ${userMap[user.id]}`).join('\n'))
+    response(rankings.map((user, index) => `${index + 1}) ${userMap[user.id]} (${users.getRankingForPretty(user.id)}%)`).join('\n'))
     return;
   });
 };

--- a/lib/models/users.js
+++ b/lib/models/users.js
@@ -15,6 +15,11 @@ users.getRankingFor = function (id) {
   return (wins + constant * this.getWinAverage()) / (wins + losses + constant);
 };
 
+users.getRankingForPretty = function (id) {
+  uglyRanking = this.getRankingFor(id);
+  return (parseFloat(Math.round(uglyRanking * 10000) / 100).toFixed(2));
+};
+
 users.rank = function () {
   return this.chain()
     .sortBy((user) => this.getRankingFor(user.id))


### PR DESCRIPTION
Since we stopped showing wins and losses on `!stats`, show our "weighted win percentage" instead.
